### PR TITLE
Fix cleanup logic to first check config_settings

### DIFF
--- a/src/pdm/backend/base.py
+++ b/src/pdm/backend/base.py
@@ -181,11 +181,22 @@ class Builder:
     def build(self, build_dir: str, **kwargs: Any) -> Path:
         """Build the package and return the path to the artifact."""
         context = self.build_context(Path(build_dir), **kwargs)
-        if (
-            not self.config_settings.get("no-clean-build")
-            or os.getenv("PDM_BUILD_NO_CLEAN", "false").lower() == "false"
-        ):
+        should_clean = True
+
+        if self.config_settings.get("no-clean-build") is not None:
+            should_clean = not self.config_settings.get("no-clean-build")
+            print(
+                "SHOULD CLEAN",
+                should_clean,
+                "NOCLEANBUILD",
+                self.config_settings.get("no-clean-build"),
+            )
+        elif os.getenv("PDM_BUILD_NO_CLEAN") is not None:
+            should_clean = os.getenv("PDM_BUILD_NO_CLEAN") == "false"
+
+        if should_clean:
             self.clean(context)
+
         self.initialize(context)
         files = sorted(self.get_files(context))
         artifact = self.build_artifact(context, files)

--- a/src/pdm/backend/base.py
+++ b/src/pdm/backend/base.py
@@ -182,7 +182,7 @@ class Builder:
         """Build the package and return the path to the artifact."""
         context = self.build_context(Path(build_dir), **kwargs)
         if not (
-            self.config_settings.get("no-clean-build")
+            "no-clean-build" in self.config_settings
             or os.getenv("PDM_BUILD_NO_CLEAN", "false").lower() not in ("0", "false")
         ):
             self.clean(context)

--- a/src/pdm/backend/base.py
+++ b/src/pdm/backend/base.py
@@ -185,12 +185,6 @@ class Builder:
 
         if self.config_settings.get("no-clean-build") is not None:
             should_clean = not self.config_settings.get("no-clean-build")
-            print(
-                "SHOULD CLEAN",
-                should_clean,
-                "NOCLEANBUILD",
-                self.config_settings.get("no-clean-build"),
-            )
         elif os.getenv("PDM_BUILD_NO_CLEAN") is not None:
             should_clean = os.getenv("PDM_BUILD_NO_CLEAN") == "false"
 

--- a/src/pdm/backend/base.py
+++ b/src/pdm/backend/base.py
@@ -186,7 +186,7 @@ class Builder:
         if self.config_settings.get("no-clean-build") is not None:
             should_clean = not self.config_settings.get("no-clean-build")
         elif os.getenv("PDM_BUILD_NO_CLEAN") is not None:
-            should_clean = os.getenv("PDM_BUILD_NO_CLEAN") == "false"
+            should_clean = os.getenv("PDM_BUILD_NO_CLEAN").lower() == "false"
 
         if should_clean:
             self.clean(context)

--- a/src/pdm/backend/base.py
+++ b/src/pdm/backend/base.py
@@ -181,14 +181,10 @@ class Builder:
     def build(self, build_dir: str, **kwargs: Any) -> Path:
         """Build the package and return the path to the artifact."""
         context = self.build_context(Path(build_dir), **kwargs)
-        should_clean = True
-
-        if self.config_settings.get("no-clean-build") is not None:
-            should_clean = not self.config_settings.get("no-clean-build")
-        elif os.getenv("PDM_BUILD_NO_CLEAN") is not None:
-            should_clean = os.getenv("PDM_BUILD_NO_CLEAN").lower() == "false"
-
-        if should_clean:
+        if not (
+            self.config_settings.get("no-clean-build")
+            or os.getenv("PDM_BUILD_NO_CLEAN", "false").lower() not in ("0", "false")
+        ):
             self.clean(context)
 
         self.initialize(context)


### PR DESCRIPTION
Currently the logic is broken if running `pdm install` or `pdm build` as the environment variable is ignored unless `config_setting` is set. The logic is confusing. 

The code has been changed to first check `config_setting` and evaluate the given value. If unset, check the environment variable. If nothing is set, cleanup by default.