### PR TITLE
fix: rename tag-pattern to tag_regex in the docs

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -49,7 +49,7 @@ You can specify another regex pattern to match the SCM tag, in which a `version`
 ```toml
 [tool.pdm.version]
 source = "scm"
-tag-pattern =  r"^(?:\D*)?(?P<version>([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|c|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$)$"
+tag_regex = '^(?:\D*)?(?P<version>([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|c|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$)$'
 ```
 
 ### Get with a specific function


### PR DESCRIPTION
Rename `tag-pattern` to `tag_regex` in the [docs](https://pdm-backend.fming.dev/metadata/#read-from-scm-tag-supporting-git-and-hg).

Since this feature was imported in #148 due to #139, there may be a gap between the origin proposal in the issue and implementation.