### PR TITLE
Add tag filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,27 @@ jobs:
         run: |
           python -m pip install -U pip pytest setuptools editables
           pip install .
+      - name: Install Mercurial
+        shell: bash
+        run: |
+          case "$RUNNER_OS" in
+            "Linux")
+              sudo apt install mercurial
+              ;;
+            "Windows")
+              choco install hg
+              ;;
+            "macOS")
+              brew install mercurial
+              ;;
+            "*")
+              echo "$RUNNER_OS not supported"
+              exit 1
+              ;;
+          esac
+
+          echo "[ui]" >> ~/.hgrc
+          echo "username = \"John Doe <ci@test.org>\"" >> ~/.hgrc
       - name: Run Tests
         run: |
           git config --global user.name "John Doe"

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -53,13 +53,24 @@ Alternatively, you can specify a default version in the configuration:
 fallback_version = "0.0.0"
 ```
 
-You can specify another regex pattern to match the SCM tag, in which a `version` group is required:
+To control which scm tags are used to generate the version, you can use two
+fields: `tag_filter` and `tag_regex`.
 
 ```toml
 [tool.pdm.version]
 source = "scm"
-tag_regex = '^(?:\D*)?(?P<version>([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|c|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$)$'
+tag_filter = "test/*"
+tag_regex = '^test/(?:\D*)?(?P<version>([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|c|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$)$'
 ```
+
+`tag_filter` filters the set of tags which are considered as candidates to
+capture your project's version. For `git` repositories, this field is a glob
+matched against the tag. For `hg` repositories, it is a regular expression used
+with the `latesttag` function.
+
+`tag_regex` configures how you extract a version from a tag. It is applied after
+`tag_filter` extracts candidate tags to extract the version from that tag. It is
+a python style regular expression.
 
 +++ 2.2.0
 
@@ -117,10 +128,10 @@ write_template = "__version__ = '{}'"
 ```
 
 !!! note
-    The path in `write_to` is relative to the root of the wheel file, hence the `package-dir` part should be stripped.
+The path in `write_to` is relative to the root of the wheel file, hence the `package-dir` part should be stripped.
 
 !!! note
-    `pdm-backend` will rewrite the whole file each time, so you can't have additional contents in that file.
+`pdm-backend` will rewrite the whole file each time, so you can't have additional contents in that file.
 
 ## Variables expansion
 
@@ -159,7 +170,7 @@ dependencies = [
 ```
 
 !!! note
-    The triple slashes `///` is required for the compatibility of Windows and POSIX systems.
+The triple slashes `///` is required for the compatibility of Windows and POSIX systems.
 
 !!! note
-    The relative paths will be expanded into the absolute paths on the local machine. So it makes no sense to include them in a distribution, since others who install the package will not have the same paths.
+The relative paths will be expanded into the absolute paths on the local machine. So it makes no sense to include them in a distribution, since others who install the package will not have the same paths.

--- a/pdm.lock
+++ b/pdm.lock
@@ -750,7 +750,7 @@ files = [
 
 [[package]]
 name = "python-dateutil"
-version = "2.8.2"
+version = "2.9.0.post0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Extensions to the standard Python datetime module"
 groups = ["docs"]
@@ -758,8 +758,8 @@ dependencies = [
     "six>=1.5",
 ]
 files = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
 
 [[package]]

--- a/src/pdm/backend/hooks/version/__init__.py
+++ b/src/pdm/backend/hooks/version/__init__.py
@@ -75,6 +75,7 @@ class DynamicVersionBuildHook:
         write_to: str | None = None,
         write_template: str = "{}\n",
         tag_regex: str | None = None,
+        tag_filter: str | None = None,
         version_format: str | None = None,
         fallback_version: str | None = None,
     ) -> str:
@@ -88,7 +89,10 @@ class DynamicVersionBuildHook:
             else:
                 version_formatter = None
             version = get_version_from_scm(
-                context.root, tag_regex=tag_regex, version_formatter=version_formatter
+                context.root,
+                tag_regex=tag_regex,
+                version_formatter=version_formatter,
+                tag_filter=tag_filter,
             )
             if version is None:
                 if fallback_version is not None:

--- a/src/pdm/backend/utils.py
+++ b/src/pdm/backend/utils.py
@@ -107,7 +107,7 @@ def find_packages_iter(
 
 
 @contextmanager
-def cd(path: str) -> Generator[None, None, None]:
+def cd(path: str | Path) -> Generator[None, None, None]:
     _old_cwd = os.getcwd()
     os.chdir(path)
     try:

--- a/tests/pdm/backend/hooks/version/test_scm.py
+++ b/tests/pdm/backend/hooks/version/test_scm.py
@@ -1,0 +1,283 @@
+import re
+import shutil
+import subprocess
+import tempfile
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Union, cast
+
+import pytest
+
+from pdm.backend.hooks.version.scm import get_version_from_scm
+
+# Copied from https://semver.org/
+# fmt: off
+_SEMVER_REGEX = re.compile(
+    r"^(?P<major>0|[1-9]\d*)"
+    r"\.(?P<minor>0|[1-9]\d*)"
+    r"\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+      r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+# fmt: on
+
+
+def increment_patch(version: str) -> str:
+    m = _SEMVER_REGEX.match(version)
+    assert m is not None, "Version provided doesn't match semver regex"
+
+    result = [m["major"], ".", m["minor"], ".", str(int(m["patch"]) + 1)]
+    if "prerelease" in m.groups():
+        result.append("-")
+        result.append(m["prerelease"])
+
+    if "buildmetadata" in m.groups():
+        result.append("+")
+        result.append(m["buildmetadata"])
+
+    return "".join(result)
+
+
+class Scm(ABC):
+    """Common interface for different source code management solutions"""
+
+    __slots__ = (
+        "_cmd",
+        "_cwd",
+    )
+
+    def __init__(self, cmd: Path, cwd: Path) -> None:
+        """Creates a new Scm
+
+        Args:
+            cmd: The base command to use for the scm
+            cwd: The working directory to use when running these commands
+        """
+        self._cmd = cmd
+        self._cwd = cwd
+
+        self._init()
+
+    def run(self, *args: Union[str, Path]):
+        result = subprocess.run(
+            [self._cmd, *args],
+            capture_output=True,
+            encoding="utf-8",
+            check=True,
+            cwd=self._cwd,
+        )
+        return result.stdout
+
+    @abstractmethod
+    def _init(self):
+        """Initializes the SCM system in the provided directory"""
+        ...
+
+    @abstractmethod
+    def commit(self, commit_message: str, files: List[Path]):
+        """Creates a commit
+
+        Args:
+            commit_message: The message to store for the commit
+            files: The files to include when creating the commit
+        """
+        ...
+
+    @abstractmethod
+    def tag(self, name: str):
+        """Create a tag
+
+        Args:
+            name: The name for the provided tag
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def current_hash(self) -> str: ...
+
+
+class GitScm(Scm):
+    def __init__(self, cmd: Path, cwd: Path) -> None:
+        super().__init__(cmd, cwd)
+        self.run("config", "commit.gpgsign", "false")
+
+    def _init(self):
+        self.run("init")
+
+    def commit(self, commit_message: str, files: List[Path]):
+        self.run("add", *files)
+        self.run("commit", "-m", commit_message)
+
+    def tag(self, name: str):
+        self.run("tag", "-am", "some tag", name)
+
+    @property
+    def current_hash(self) -> str:
+        return "g" + self.run("rev-parse", "--short", "HEAD").strip()
+
+
+class HgScm(Scm):
+    def _init(self):
+        self.run("init")
+
+    def commit(self, commit_message: str, files: List[Path]):
+        self.run("add", *files)
+        self.run("commit", "-m", commit_message, *files)
+
+    def tag(self, name: str):
+        self.run("tag", name)
+
+    @property
+    def current_hash(self) -> str:
+        return self.run("id", "-i").strip()
+
+
+@pytest.fixture
+def scm_dir() -> Iterable:
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+@pytest.fixture
+def git(scm_dir: Path) -> GitScm:
+    git = shutil.which("git")
+    assert git is not None, "Cannot find git in path"
+
+    scm = GitScm(Path(git), scm_dir)
+
+    return scm
+
+
+@pytest.fixture
+def hg(scm_dir: Path) -> HgScm:
+    hg = shutil.which("hg")
+    assert hg is not None, "Cannot find hg in path"
+
+    scm = HgScm(Path(hg), scm_dir)
+
+    return scm
+
+
+@pytest.fixture(params=["git", "hg"])
+def scm(request: pytest.FixtureRequest, scm_dir: Path) -> Scm:
+    scm = cast(Scm, request.getfixturevalue(request.param))
+
+    file_path = scm_dir / "test.txt"
+    with open(file_path, "w") as f:
+        f.write("a\n")
+
+    scm.commit("Add a", [file_path])
+
+    return scm
+
+
+def test__get_version_from_scm__returns_tag_if_method_unspecified(
+    scm_dir: Path, scm: Scm
+):
+    expected_tag = "0.2.52"
+    scm.tag(expected_tag)
+
+    version = get_version_from_scm(scm_dir)
+
+    assert version is not None
+    assert version == expected_tag
+
+
+def test__get_version_from_scm__adds_details_if_project_is_dirty(
+    scm_dir: Path, scm: Scm
+):
+    expected_tag = "0.2.52"
+    file_path = scm_dir / "some_file.txt"
+
+    with open(file_path, "w") as f:
+        f.write("having fun\n")
+    scm.commit("some commit", [file_path])
+    scm.tag(expected_tag)
+    with open(file_path, "a") as f:
+        f.write("having fun 2\n")
+
+    version = get_version_from_scm(scm_dir)
+
+    assert version is not None
+    assert version == f"{expected_tag}+d{datetime.now(timezone.utc).strftime('%Y%m%d')}"
+
+
+def test__get_version_from_scm__returns_version_if_tag_has_v(scm_dir: Path, scm: Scm):
+    expected_tag = "0.2.52"
+    scm.tag(f"v{expected_tag}")
+
+    version = get_version_from_scm(scm_dir)
+
+    assert version is not None
+    assert version == expected_tag
+
+
+def test__get_version_from_scm__returns_default_if_tag_cannot_be_parsed(
+    scm_dir: Path, scm: Scm
+):
+    scm.tag("some-tag-without-numbers")
+
+    version = get_version_from_scm(scm_dir)
+
+    assert version is not None
+    assert version == f"0.1.dev1+{scm.current_hash}"
+
+
+def test__get_version_from_scm__tag_regex(scm_dir: Path, scm: Scm):
+    expected_version = "7.2.9"
+    tag_regex = "foo/bar-v(?P<version>.*)"
+    scm.tag(f"foo/bar-v{expected_version}")
+
+    version = get_version_from_scm(scm_dir, tag_regex=tag_regex)
+
+    assert version is not None
+    assert version == expected_version
+
+
+@pytest.mark.parametrize("index", [0, 1])
+def test__get_version_from_scm__selects_by_tag_filter_on_same_commit(
+    scm_dir: Path, scm: Scm, index: int
+):
+    expected_versions = ["4.8.2", "2.4.9"]
+    tag_regex = r"tag-\d/(?P<version>.*)"
+    for i, version in enumerate(expected_versions):
+        scm.tag(f"tag-{i}/v{version}")
+
+    version = get_version_from_scm(
+        scm_dir, tag_regex=tag_regex, tag_filter=f"tag-{index}/v*"
+    )
+
+    assert version is not None
+    assert version == expected_versions[index]
+
+
+@pytest.mark.parametrize("index", [0, 1])
+def test__get_version_from_scm__selects_by_tag_filter_on_different_commits(
+    scm_dir: Path, scm: Scm, index: int
+):
+    expected_versions = ["4.8.2", "2.4.9"]
+    tag_regex = r"tag-\d/(?P<version>.*)"
+    for i, version in enumerate(expected_versions):
+        file_path = scm_dir / "test_{i}.txt"
+        with open(file_path, "w") as f:
+            f.write(f"Testing {i}\n")
+        scm.commit(f"Add {i}", [file_path])
+        scm.tag(f"tag-{i}/v{version}")
+
+    file_path = scm_dir / "test_end.txt"
+    with open(file_path, "w") as f:
+        f.write("Testing end\n")
+    scm.commit("Add end", [file_path])
+
+    version = get_version_from_scm(
+        scm_dir, tag_regex=tag_regex, tag_filter=f"tag-{index}/v*"
+    )
+
+    num_patches = len(expected_versions) - index
+    next_version = increment_patch(expected_versions[index])
+    assert version is not None
+    assert version == f"{next_version}.dev{num_patches}+{scm.current_hash}"


### PR DESCRIPTION
This PR adds tag_filter as a metadata property which can be used to filter the 
set of tags examined for versioning the project. More details can be found in #219.

The `git` changes in this PR are straightforward. The `hg` changes require a bit more context.

In order to tags, it was necessary to use `hg log` as it provides a `--template` argument to use
with the `latesttag` function. Technically `hg`'s regex is a python style regex, but I didn't think
it prudent to depend on that exact implementation detail. Instead, I refactored the implementation
slightly so that we use `hg log` to extract the current commit and `hg id` is relegated to telling us
if the working tree is dirty.

This is a PR that's stacked on top of #224. For easy of review, I suggest you look at only the
most recent commit. All other changes are captured in #224.

Resolves #219 