### PR TITLE
Fixed error about dynamic project version

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -87,13 +87,13 @@ def format_version(version: SCMVersion) -> str:
 ```toml
 [tool.pdm.version]
 source = "call"
-getter = "mypackage.version.get_version"
+getter = "mypackage.version:get_version"
 ```
 
 You can also supply it with literal arguments:
 
 ```toml
-getter = "mypackage.version.get_version('dev')"
+getter = "mypackage.version:get_version('dev')"
 ```
 
 ### Writing dynamic version to file

--- a/src/pdm/backend/utils.py
+++ b/src/pdm/backend/utils.py
@@ -215,7 +215,10 @@ def evaluate_module_attribute(
         obj: Any = functools.reduce(getattr, attrs, module)
         args_group = matched.group(3)
         if args_group:
+            # make tuple
+            args_group = args_group.strip()[:-1] + ",)"
             args = ast.literal_eval(args_group)
+
         else:
             args = ()
         return obj, args


### PR DESCRIPTION
- fixed error in document regarding `Get with a specific function` section. More details can be found in #234.
- fixed the issue where single string literal parameters were not correctly handled during parameter parsing.

---
The second fix is necessary because `ast.literal_eval("('example')")` parses the input as a string type instead of a tuple type. 

Fixed #234 