### PR TITLE
fix: handle unexpected hg repo when parse scm version

### DIFF
--- a/src/pdm/backend/hooks/version/scm.py
+++ b/src/pdm/backend/hooks/version/scm.py
@@ -287,7 +287,10 @@ def hg_parse_version(root: StrPath, config: Config) -> SCMVersion | None:
         root,
     )
     tag: str | None
-    tag, node, branch = output.rsplit("-", 2)
+    try:
+        tag, node, branch = output.rsplit("-", 2)
+    except ValueError:
+        return None  # unpacking failed, unexpected hg repo
     # If no tag exists passes the tag filter.
     if tag == "null":
         tag = None


### PR DESCRIPTION
The error happens when running `pdm install` in a git repo while `git` command does not work as expected but `hg` command is available.

For my case, the permission of `.git` directory is invalid when I try to mount the working directory into a container and then the error happen. Though it is not a critical error, it might be better to handle it well.

traceback for the error:

```
Traceback (most recent call last):
  File "/usr/local/bin/pdm", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/core.py", line 358, in main
    return core.main(args or sys.argv[1:])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/core.py", line 276, in main
    raise cast(Exception, err).with_traceback(traceback) from None
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/core.py", line 271, in main
    self.handle(project, options)
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/core.py", line 207, in handle
    command.handle(project, options)
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/cli/commands/install.py", line 100, in handle
    actions.do_sync(
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/cli/actions.py", line 238, in do_sync
    synchronizer.synchronize()
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/installers/synchronizers.py", line 475, in synchronize
    self.install_candidate(self_key, progress)
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/installers/synchronizers.py", line 282, in install_candidate
    self.manager.install(can)
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/installers/manager.py", line 33, in install
    prepared.build(),
    ^^^^^^^^^^^^^^^^
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/models/candidates.py", line 416, in build
    self._cached = Path(builder.build(build_dir, metadata_directory=self._metadata_dir))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/builders/editable.py", line 36, in build
    filename = self._hook.build_editable(out_dir, self.config_settings, metadata_directory)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pyproject_hooks/_impl.py", line 339, in build_editable
    return self._call_hook(
           ^^^^^^^^^^^^^^^^
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pyproject_hooks/_impl.py", line 392, in _call_hook
    self._subprocess_runner(
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/builders/base.py", line 259, in subprocess_runner
    return log_subprocessor(cmd, cwd, extra_environ=env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/builders/base.py", line 106, in log_subprocessor
    raise build_error(e) from None
pdm.exceptions.BuildError: Build backend raised error: Showing the last 10 lines of the build output:
  File "/tmp/pdm-build-env-evu4ajha-shared/lib/python3.11/site-packages/pdm/backend/hooks/version/__init__.py", line 91, in resolve_version_from_scm
    version = get_version_from_scm(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/pdm-build-env-evu4ajha-shared/lib/python3.11/site-packages/pdm/backend/hooks/version/scm.py", line 341, in get_version_from_scm
    version = func(root, config)
              ^^^^^^^^^^^^^^^^^^
  File "/tmp/pdm-build-env-evu4ajha-shared/lib/python3.11/site-packages/pdm/backend/hooks/version/scm.py", line 290, in hg_parse_version
    tag, node, branch = output.rsplit("-", 2)
    ^^^^^^^^^^^^^^^^^
```

GitHub workflow run: https://github.com/huxuan/ss-python/actions/runs/8983209042/job/24672464323