### PR TITLE
Treat PDM_BUILD_SCM_VERSION empty string as unset

### DIFF
--- a/src/pdm/backend/hooks/version/__init__.py
+++ b/src/pdm/backend/hooks/version/__init__.py
@@ -79,7 +79,7 @@ class DynamicVersionBuildHook:
         version_format: str | None = None,
         fallback_version: str | None = None,
     ) -> str:
-        if "PDM_BUILD_SCM_VERSION" in os.environ:
+        if os.environ.get("PDM_BUILD_SCM_VERSION"):
             version = os.environ["PDM_BUILD_SCM_VERSION"]
         else:
             if version_format is not None:


### PR DESCRIPTION
Doesn't makes sense to have a empty version, make easier to treat PDM_BUILD_SCM_VERSION as empty string when you don't have tag information, and instead, use fallback_version.

![Screenshot from 2024-05-14 12-19-19](https://github.com/pdm-project/pdm-backend/assets/7642878/deb085e1-9257-48a3-9672-9b7e045c369d)

![image](https://github.com/pdm-project/pdm-backend/assets/7642878/8321cc13-788c-4ed2-bbef-41bf33adc215)
