### PR TITLE
Add ASCIIDoc format to allowed README and description content-types

### DIFF
--- a/src/pdm/backend/_vendor/packaging/metadata.py
+++ b/src/pdm/backend/_vendor/packaging/metadata.py
@@ -575,7 +575,7 @@ class _Validator(Generic[T]):
         return value
 
     def _process_description_content_type(self, value: str) -> str:
-        content_types = {"text/plain", "text/x-rst", "text/markdown"}
+        content_types = {"text/plain", "text/x-rst", "text/markdown", "text/asciidoc"}
         message = email.message.EmailMessage()
         message["content-type"] = value
 

--- a/src/pdm/backend/_vendor/pyproject_metadata/__init__.py
+++ b/src/pdm/backend/_vendor/pyproject_metadata/__init__.py
@@ -417,6 +417,8 @@ class StandardMetadata:
                 content_type = 'text/markdown'
             elif filename.endswith('.rst'):
                 content_type = 'text/x-rst'
+            elif filename.endswith(('.adoc', '.asc', '.asciidoc')):
+                content_type = 'text/asciidoc'
             else:
                 msg = f'Could not infer content type for readme file "{filename}"'
                 raise ConfigurationError(msg, key='project.readme')


### PR DESCRIPTION
ASCIIDoc, in formats `.adoc`, `.asc`, and `.asciidoc` is supported by GitHub. I personally prefer it to Markdown due to its degree of standardization, and would like to add it to the list of supported content-types for README files, and description.