### PR TITLE
fix: support a SOURCE_DATE_EPOCH prior to 1980

### DIFF
--- a/src/pdm/backend/wheel.py
+++ b/src/pdm/backend/wheel.py
@@ -48,9 +48,8 @@ try:
 except (ValueError, KeyError):
     ZIPINFO_DATE_TIME = (2016, 1, 1, 0, 0, 0)
 else:
-    if _env_date[0] < 1980:
-        raise ValueError("zipinfo date can't be earlier than 1980")
-    ZIPINFO_DATE_TIME = _env_date
+    # `zipfile.ZipInfo` does not support timestamps before 1980
+    ZIPINFO_DATE_TIME = max(_env_date, (1980, 1, 1, 0, 0, 0))
 
 
 def _open_for_write(path: str | Path) -> IO[str]:


### PR DESCRIPTION
A common value for `SOURCE_DATE_EPOCH` is 0, which unfortunately breaks pdm:

```console
$ uv init --build-backend=pdm
$ SOURCE_DATE_EPOCH=0 uv build
# ...
  File "/Users/branch/.cache/uv/builds-v0/.tmpEkVowp/lib/python3.13/site-packages/pdm/backend/wheel.py", line 52, in <module>
    raise ValueError("zipinfo date can't be earlier than 1980")
ValueError: zipinfo date can't be earlier than 1980
```

This clamps to 1980 instead (same as [`setuptools`](https://github.com/pypa/setuptools/blob/c3f486f0f7ebf8fa141dfd7314cbcaba7370db0b/setuptools/_vendor/wheel/wheelfile.py#L40) and [`flit-core`](https://github.com/pypa/flit/blob/13792b5748463f1f5d37bae954e4b44d4ccb341c/flit_core/flit_core/wheel.py#L57-L59). [`poetry`](https://github.com/python-poetry/poetry-core/blob/002aa3e16f98d21645bb9a45f698b55adc40f317/src/poetry/core/masonry/builders/wheel.py#L527-L533) also support this but defaults to 2016)
