### PR TITLE
Docs: Select color scheme based on system preference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,14 +15,14 @@ theme:
       primary: deep purple
       accent: teal
       toggle:
-        icon: material/weather-sunny
+        icon: material/brightness-7
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       primary: deep purple
       accent: teal
       toggle:
-        icon: material/weather-night
+        icon: material/brightness-4
         name: Switch to system preference
   font:
     text: Open Sans


### PR DESCRIPTION
Added a toggle to select the documentation color scheme based on system preference. Additionally, the icons for light and dark mode were adjusted to match the automatic toggle icon.

Related mkdocs documentation: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode