### PR TITLE
Fixed Git versioning from multiple lightweight tags

### DIFF
--- a/src/pdm/backend/hooks/version/scm.py
+++ b/src/pdm/backend/hooks/version/scm.py
@@ -223,7 +223,7 @@ def git_parse_version(root: StrPath, config: Config) -> SCMVersion | None:
         )
     else:
         tag, number, node, dirty = _git_parse_describe(output)
-        tag_cmd = (git, 'tag', '--list', '--points-at', tag)
+        tag_cmd = (git, "tag", "--list", "--points-at", tag)
         ret, output, _ = _subprocess_call(tag_cmd, repo)
         if not ret and output:
             tag = str(max(output.splitlines(), key=Version))

--- a/src/pdm/backend/hooks/version/scm.py
+++ b/src/pdm/backend/hooks/version/scm.py
@@ -223,6 +223,10 @@ def git_parse_version(root: StrPath, config: Config) -> SCMVersion | None:
         )
     else:
         tag, number, node, dirty = _git_parse_describe(output)
+        tag_cmd = (git, 'tag', '--list', '--points-at', tag)
+        ret, output, _ = _subprocess_call(tag_cmd, repo)
+        if not ret and output:
+            tag = str(max(output.splitlines(), key=Version))
         return meta(config, tag, number or None, dirty, node, branch)
 
 


### PR DESCRIPTION
When using the SCM Git version hook, if multiple lightweight tags are present on the current ref, `git describe` does not always select the latest one (it is impossible as they don't have timestamps).

Example:
```console
$ git log
commit abcdef (tag: v1.1, tag: v1.2, HEAD)

$ git describe --tags
v1.1

$ git tag --points-to=HEAD
v1.1
v1.2
```

This introduces an additional `git tag` query that picks the highest version tag if multiple are found.

This is technically a breaking change that actually fixes unintuitive behavior on a rare edge case (e.g. automated tagging).