### PR TITLE
`pdm_configure` hook method

### DIFF
--- a/src/pdm/backend/base.py
+++ b/src/pdm/backend/base.py
@@ -162,7 +162,7 @@ class Builder:
 
     def configure(self, context: Context) -> None:
         """Finalize and validate configuration, calling hooks"""
-        self.call_hook("pdm_configure", context)
+        self.call_hook("pdm_build_configure", context)
         self.config.validate()
 
     def clean(self, context: Context) -> None:

--- a/src/pdm/backend/base.py
+++ b/src/pdm/backend/base.py
@@ -99,7 +99,7 @@ class Builder:
     ) -> None:
         self._old_cwd: str | None = None
         self.location = Path(location)
-        self.config = Config.from_pyproject(self.location)
+        self.config = Config.from_pyproject(self.location, validate=False)
         self.config_settings = dict(config_settings or {})
         self._hooks = list(self.get_hooks())
 
@@ -160,6 +160,11 @@ class Builder:
         assert self._old_cwd
         os.chdir(self._old_cwd)
 
+    def configure(self, context: Context) -> None:
+        """Finalize and validate configuration, calling hooks"""
+        self.call_hook("pdm_configure", context)
+        self.config.validate()
+
     def clean(self, context: Context) -> None:
         """Clean up the build directory."""
         self.call_hook("pdm_build_clean", context)
@@ -202,6 +207,8 @@ class Builder:
     def build(self, build_dir: str, **kwargs: Any) -> Path:
         """Build the package and return the path to the artifact."""
         context = self.build_context(Path(build_dir), **kwargs)
+        self.configure(context)
+
         should_clean = True
 
         if "no-clean-build" in self.config_settings:

--- a/src/pdm/backend/config.py
+++ b/src/pdm/backend/config.py
@@ -35,16 +35,18 @@ class Config:
     Parameters:
         root: The root directory of the project
         data: The parsed pyproject.toml data
+        validate: Perform validation immediately on instantiation.
 
     Attributes:
         metadata (Metadata): The project metadata from the `project` table
         build_config (BuildConfig): The build config from the `tool.pdm.build` table
     """
 
-    def __init__(self, root: Path, data: dict[str, Any]) -> None:
+    def __init__(self, root: Path, data: dict[str, Any], validate: bool = True) -> None:
         self.root = root
         self.data = data
-        self.validate()
+        if validate:
+            self.validate()
 
     def validate(self) -> StandardMetadata:
         """Validate the pyproject.toml data."""
@@ -64,7 +66,7 @@ class Config:
         )
 
     @classmethod
-    def from_pyproject(cls, root: str | Path) -> Config:
+    def from_pyproject(cls, root: str | Path, validate: bool = True) -> Config:
         """Load the pyproject.toml file from the given project root."""
         root = Path(root)
         pyproject = root / "pyproject.toml"
@@ -75,7 +77,7 @@ class Config:
                 data = tomllib.load(fp)
             except tomllib.TOMLDecodeError as e:
                 raise ConfigError(f"Invalid pyproject.toml file: {e}") from e
-        return cls(root, data)
+        return cls(root, data, validate=validate)
 
     def write_to(self, path: str | Path) -> None:
         """Write the pyproject.toml file to the given path."""

--- a/src/pdm/backend/hooks/base.py
+++ b/src/pdm/backend/hooks/base.py
@@ -88,6 +88,12 @@ class BuildHookInterface(Protocol):
         """
         ...
 
+    def pdm_build_configure(self, context: Context) -> None:
+        """Wraps the pyproject.toml configuration loading and validation.
+        Modify values or prepare the build environment before the config is validated.
+        """
+        ...
+
     def pdm_build_clean(self, context: Context) -> None:
         """An optional clean step which will be called before the build starts
 

--- a/tests/fixtures/hooks/hook_class.py
+++ b/tests/fixtures/hooks/hook_class.py
@@ -13,8 +13,8 @@ class BuildHook:
     def __init__(self, name: str = "2") -> None:
         self.name = name
 
-    def pdm_configure(self, context: Context) -> None:
-        logger.info("Hook%s configure called", self.name)
+    def pdm_build_configure(self, context: Context) -> None:
+        logger.info("Hook%s build configure called", self.name)
 
     def pdm_build_clean(self, context: Context) -> None:
         logger.info("Hook%s build clean called", self.name)

--- a/tests/fixtures/hooks/hook_class.py
+++ b/tests/fixtures/hooks/hook_class.py
@@ -13,6 +13,9 @@ class BuildHook:
     def __init__(self, name: str = "2") -> None:
         self.name = name
 
+    def pdm_configure(self, context: Context) -> None:
+        logger.info("Hook%s configure called", self.name)
+
     def pdm_build_clean(self, context: Context) -> None:
         logger.info("Hook%s build clean called", self.name)
 

--- a/tests/fixtures/hooks/hook_module.py
+++ b/tests/fixtures/hooks/hook_module.py
@@ -8,8 +8,8 @@ from pdm.backend.hooks.base import Context
 logger = logging.getLogger("hooks")
 
 
-def pdm_configure(context: Context) -> None:
-    logger.info("Hook1 configure called")
+def pdm_build_configure(context: Context) -> None:
+    logger.info("Hook1 build configure called")
 
 
 def pdm_build_clean(context: Context) -> None:

--- a/tests/fixtures/hooks/hook_module.py
+++ b/tests/fixtures/hooks/hook_module.py
@@ -8,6 +8,10 @@ from pdm.backend.hooks.base import Context
 logger = logging.getLogger("hooks")
 
 
+def pdm_configure(context: Context) -> None:
+    logger.info("Hook1 configure called")
+
+
 def pdm_build_clean(context: Context) -> None:
     logger.info("Hook1 build clean called")
 

--- a/tests/fixtures/hooks/local_hook.py
+++ b/tests/fixtures/hooks/local_hook.py
@@ -8,6 +8,10 @@ from pdm.backend.hooks.base import Context
 logger = logging.getLogger("hooks")
 
 
+def pdm_configure(context: Context) -> None:
+    logger.info("Hook4 configure called")
+
+
 def pdm_build_clean(context: Context) -> None:
     logger.info("Hook4 build clean called")
 

--- a/tests/fixtures/hooks/local_hook.py
+++ b/tests/fixtures/hooks/local_hook.py
@@ -8,8 +8,8 @@ from pdm.backend.hooks.base import Context
 logger = logging.getLogger("hooks")
 
 
-def pdm_configure(context: Context) -> None:
-    logger.info("Hook4 configure called")
+def pdm_build_configure(context: Context) -> None:
+    logger.info("Hook4 build configure called")
 
 
 def pdm_build_clean(context: Context) -> None:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -43,7 +43,7 @@ def test_load_hooks(project_with_hooks, caplog: pytest.LogCaptureFixture):
 
     messages = [record.message for record in caplog.records if record.name == "hooks"]
     for num in range(1, 5):
-        assert f"Hook{num} configure called" in messages
+        assert f"Hook{num} build configure called" in messages
         assert f"Hook{num} build clean called" in messages
         assert f"Hook{num} build initialize called" in messages
         assert f"Hook{num} build update files called" in messages

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -43,6 +43,7 @@ def test_load_hooks(project_with_hooks, caplog: pytest.LogCaptureFixture):
 
     messages = [record.message for record in caplog.records if record.name == "hooks"]
     for num in range(1, 5):
+        assert f"Hook{num} configure called" in messages
         assert f"Hook{num} build clean called" in messages
         assert f"Hook{num} build initialize called" in messages
         assert f"Hook{num} build update files called" in messages


### PR DESCRIPTION
Fix: https://github.com/pdm-project/pdm/issues/3824

This problem has blocked me so i had some time to work on it:

There is a problem with the packaging spec such that it is ambiguous what to do with a `'../../README.md'` outside of the path of the package root. this is common in monorepos. However
- having the readme in the repo root and using a `../../` relative path breaks builds, as the tarfile library refuses to unpack files outside of the directory
- having the configuration use `readme="README.md"` and then copying from the repo root is impossible, because the `Config` object fails validation since the readme file doesn't exist.

however, rather than making some unspec'd behavior a part of the builder, @frostming suggested that a configuration hook might be an acceptable fix to the problem. This is a more generally useful change, as currently all the hooks run after the configuration has been validated. If there is any customization that needs to happen that *relates* to the configuration, i.e. avoiding the above configuration error, copying a file so the configuration is valid, then it can use this hook. This effectively makes any field dynamic if people want it to be.

Other parts of the builder need the `config` (including getting the hooks itself), so I couldn't just have a hook that happens entirely before the configuration is loaded. That would also make it impossible to mutate the config, which sort of defeats the purpose of the hook. So I split the validation phase of the `Config` object out of its `__init__` method, and it is called after the hook is called.

I just wanted to open this as a draft at first to see if it would be acceptable, and if it is I can also update the docs to match. I didn't see other hooks having specific behavioral tests so I didn't add them, but if we want to have a test that the hook can mutate and correct an invalid `pyproject.toml` config, just let me know.

happy to make any changes!